### PR TITLE
DS-2852

### DIFF
--- a/dspace-xmlui-mirage2/src/main/webapp/templates/discovery_simple_filters.hbs
+++ b/dspace-xmlui-mirage2/src/main/webapp/templates/discovery_simple_filters.hbs
@@ -8,5 +8,5 @@
 
 -->
 {{#each orig_filters}}
-    <label href="#" class="label label-primary" data-index="{{index}}">{{query}}&nbsp;&times;</label>
+    <label href="#" class="label label-primary" data-index="{{index}}">{{display_query}}&nbsp;&times;</label>
 {{/each}}

--- a/dspace-xmlui-mirage2/src/main/webapp/xsl/aspect/discovery/discovery.xsl
+++ b/dspace-xmlui-mirage2/src/main/webapp/xsl/aspect/discovery/discovery.xsl
@@ -401,6 +401,7 @@
                     type: '</xsl:text><xsl:value-of select="stringescapeutils:escapeEcmaScript(dri:cell/dri:field[starts-with(@n, 'filtertype')]/dri:value/@option)"/><xsl:text>',
                     relational_operator: '</xsl:text><xsl:value-of select="stringescapeutils:escapeEcmaScript(dri:cell/dri:field[starts-with(@n, 'filter_relational_operator')]/dri:value/@option)"/><xsl:text>',
                     query: '</xsl:text><xsl:value-of select="stringescapeutils:escapeEcmaScript(dri:cell/dri:field[@rend = 'discovery-filter-input']/dri:value)"/><xsl:text>',
+	                display_query: '</xsl:text><xsl:value-of select="stringescapeutils:escapeEcmaScript(util:getDiscoveryFilterDisplay(dri:cell/dri:field[@rend = 'discovery-filter-input']/dri:value))"/><xsl:text>',
                 });
             </xsl:text>
         </script>

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/ConfigurableBrowse.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/ConfigurableBrowse.java
@@ -38,6 +38,8 @@ import org.dspace.app.xmlui.wing.element.ReferenceSet;
 import org.dspace.app.xmlui.wing.element.Row;
 import org.dspace.app.xmlui.wing.element.Select;
 import org.dspace.app.xmlui.wing.element.Table;
+import org.dspace.authority.AuthorityValue;
+import org.dspace.authority.AuthorityValueFinder;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.browse.BrowseEngine;
 import org.dspace.browse.BrowseException;
@@ -904,15 +906,19 @@ public class ConfigurableBrowse extends AbstractDSpaceTransformer implements
             String value = "";
             if (info.hasValue())
             {
+	            value = "\"" + info.getValue() + "\"";
+
                 if (bix.isAuthorityIndex())
                 {
                     ChoiceAuthorityManager cm = ChoiceAuthorityManager.getManager();
                     String fk = cm.makeFieldKey(bix.getMetadata(0));
                     value = "\""+cm.getLabel(fk, info.getValue(), null)+"\"";
                 }
-                else
-                {
-                    value = "\"" + info.getValue() + "\"";
+                else if(StringUtils.isNotBlank(info.getAuthority())) {
+	                AuthorityValue authorityValue = new AuthorityValueFinder().findByUID(context, info.getAuthority());
+	                if(authorityValue != null) {
+		                value = "\"" + authorityValue.getValue() + "\"";
+	                }
                 }
             }
 

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/utils/XSLUtils.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/utils/XSLUtils.java
@@ -7,12 +7,22 @@
  */
 package org.dspace.app.xmlui.utils;
 
+import org.apache.commons.lang.StringUtils;
+import org.apache.log4j.Logger;
+import org.dspace.authority.AuthorityValue;
+import org.dspace.authority.AuthorityValueFinder;
+import org.dspace.core.Context;
+
+import java.sql.SQLException;
+import java.util.List;
+
 /**
  * Utilities that are needed in XSL transformations.
  *
  * @author Art Lowel (art dot lowel at atmire dot com)
  */
 public class XSLUtils {
+	private static final Logger log = Logger.getLogger(XSLUtils.class);
 
     /*
      * Cuts off the string at the space nearest to the targetLength if there is one within
@@ -53,4 +63,31 @@ public class XSLUtils {
         return string.substring(0, targetLength) + " ...";
 
     }
+
+	public static String getDiscoveryFilterDisplay(String display) {
+		Context ctx = null;
+
+		try {
+			ctx = new Context();
+			AuthorityValueFinder avf = new AuthorityValueFinder();
+
+			if (StringUtils.isNotBlank(display)) {
+				List<AuthorityValue> avs = avf.findAll(ctx);
+				AuthorityValue authorityValue = new AuthorityValueFinder().findByUID(ctx, display);
+				if (authorityValue != null && avs.contains(authorityValue)) {
+					display = authorityValue.getValue();
+				}
+			}
+		}
+		catch(SQLException sqle) {
+			log.error(sqle.getLocalizedMessage(), sqle);
+		}
+		finally {
+			if(ctx != null) {
+				ctx.abort();
+			}
+		}
+
+		return display;
+	}
 }

--- a/dspace/config/xmlui.xconf
+++ b/dspace/config/xmlui.xconf
@@ -182,7 +182,7 @@
         <!-- <theme name="Test Theme 2" regex="community-list" path="theme2/"/> -->
 
         <!-- Mirage theme, @mire contributed theme, default since DSpace 3.0 -->
-        <theme name="Atmire Mirage Theme" regex=".*" path="Mirage/" />
+        <theme name="Atmire Mirage Theme" regex=".*" path="Mirage2/" />
 
         <!-- Reference theme, the default Manakin XMLUI layout up to DSpace 1.8 -->
         <!-- <theme name="Default Reference Theme" regex=".*" path="Reference/" /> -->


### PR DESCRIPTION
Adjusted the discovery theming of Mirage 2 to show author names instead
of authority values.

Updated from previous one: 
- Changed check for correct display and added logging for SQLExceptions.
- Removed the change to SimpleSearch, otherwise the contains filter would be used/shown instead of authority in the advanced search filters.
- Edited class ConfigurableBrowse to fix the browse page header.
